### PR TITLE
Stop daemons before cleanup in unstack

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -82,8 +82,8 @@ if [[ "$1" == "unstack" ]]; then
     if [ "$REMOTE_CEPH" = "True" ]; then
         cleanup_ceph_remote
     else
-        cleanup_ceph_embedded
         stop_ceph
+        cleanup_ceph_embedded
     fi
     cleanup_ceph_general
 fi


### PR DESCRIPTION
The cleanup_ceph_embedded function nukes the ceph
conf directories, so when subsequently trying
to stop services they aren't stopped.  Next stack.sh
run will fail because daemons are still hanging around.

Fix by stopping daemons before running cleanup.

Closes-Bug: #1534600
