### PR TITLE
Fix RadosGW code path and common bugs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,33 @@ in the ``local.conf`` file.
 
 -  Then run ``stack.sh`` and wait for the *magic* to happen :)
 
+Setup With Rados Gateway
+------------------------
+
+To setup Ceph with Rados Gateway and configure it as a Swift endpoint, you will need to enable following setting in your ``local.conf`` in addition to the settings mentioned in the previous section:
+
+::
+
+    ENABLE_CEPH_RGW=True
+
+For a full example, please see file ``./examples/ceph-with-rgw-local.conf`` in this repository.
+
+Test With Older Ceph Releases
+-----------------------------
+
+You can build devstack with older versions of ceph releases. Change the version of ceph release by overriding variable ``CONTAINER_IMAGE`` in your configuration file.
+
+Supported releases are following:
+
+::
+
+    # Change Ceph Version by changing tag in CONTAINER_IMAGE.
+    # Supported versions are:
+    #   reef: quay.io/ceph/ceph:v18
+    #   squid: quay.io/ceph/ceph:v19
+    #   tentacle: quay.io/ceph/ceph:v20
+    CONTAINER_IMAGE=quay.io/ceph/ceph:v20
+
 Known Issues / Limitations
 --------------------------
 
@@ -77,6 +104,9 @@ Known Issues / Limitations
 -  Tempest test failures when using RGW as swift endpoint
 -  Tempest fails due to verify-tempest-config erroring out, when using
    RGW as swift endpoint
+-  Ceph requires passwordless SSH access to the ``root`` user on the machine.
+   Adding ``PermitRootLogin prohibit-password`` to the sshd_config is
+   sufficient.
 
 Bugs
 ----

--- a/devstack/lib/cephadm
+++ b/devstack/lib/cephadm
@@ -18,7 +18,6 @@ XTRACE=$(set +o | grep xtrace)
 set +o xtrace
 
 # GENERIC CEPHADM INTERNAL OPTIONS, DO NOT EDIT
-CEPH_RELEASE=${CEPH_RELEASE:-tentacle}
 CEPH_PUB_KEY="/etc/ceph/ceph.pub"
 CEPH_CONFIG="/etc/ceph/ceph.conf"
 BOOTSTRAP_CONFIG="$HOME/bootstrap_ceph.conf"
@@ -50,7 +49,7 @@ DEFAULT_PG_NUM=${DEFAULT_PG_NUM:-8}
 DEFAULT_PGP_NUM=${DEFAULT_PGP_NUM:-8}
 
 # RGW OPTIONS
-RGW_PORT=8080
+RGW_PORT=${RGW_PORT:-8080}
 
 # CLIENT CONFIG
 CEPH_CLIENT_CONFIG=$HOME/ceph_client.conf
@@ -110,24 +109,24 @@ NOVA_CEPH_POOL=${NOVA_CEPH_POOL:-vms}
 function set_debug {
     if [ "$DEBUG" -eq 1 ]; then
         echo "[CEPHADM] Enabling Debug mode"
-        $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+        $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
             --keyring $CEPH_KEYRING -- ceph config set mgr mgr/cephadm/log_to_cluster_level debug
         echo "[CEPHADM] See debug logs running: ceph -W cephadm --watch-debug"
     fi
 }
 
 function enable_verbose_mds_logging {
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph config set mds debug_mds 20
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph config set mds debug_ms 20
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph config set mds debug_client 20
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph config set mds log_to_file true
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph config set global mon_cluster_log_to_file true
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph config set global log_to_file true
     touch "$MDS_LOG_FILE"
     cat <<EOF > "$MDS_LOG_FILE"
@@ -137,7 +136,7 @@ LOG {
  }
 }
 EOF
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -m $MDS_LOG_FILE -- ceph nfs cluster config set "$FSNAME" \
         -i /mnt/mds_log.conf
 
@@ -145,13 +144,13 @@ EOF
 
 # Admin: check ceph cluster status
 function check_cluster_status {
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph -s -f json-pretty
 }
 
 # Admin: export ceph cluster config spec
 function export_spec {
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph orch ls --export > "$EXPORT"
     echo "Ceph cluster config exported: $EXPORT"
 }
@@ -168,14 +167,11 @@ function get_cephadm {
     # NOTE(gouthamr): cephadm binary here is a python executable, and the
     # $os_PACKAGE ("rpm") doesn't really matter. There is no ubuntu/debian
     # equivalent being published by the ceph community.
+
     os_release="el9"
     ceph_version=$(_get_ceph_version)
-    case $CEPH_RELEASE in
-        pacific|octopus)
-            os_release="el8";;
-    esac
     curl -f -O https://download.ceph.com/rpm-${ceph_version}/${os_release}/noarch/cephadm
-    $SUDO mv cephadm $TARGET_BIN
+    $SUDO mv cephadm $TARGET_BIN/cephadm
     $SUDO chmod +x $TARGET_BIN/cephadm
     echo "[GET CEPHADM] cephadm is now available"
 
@@ -206,6 +202,7 @@ EOF
 # Install ceph: run cephadm bootstrap
 function start_ceph {
     cluster=$(sudo cephadm ls | jq '.[]' | jq 'select(.name | test("^mon*")).fsid')
+
     if [ -z "$cluster" ]; then
         local boot_attempts=3
         while [ "$boot_attempts" -ne 0 ]; do
@@ -277,17 +274,17 @@ function add_osds {
     # let's add some osds
     if [ -z "$DEVICES" ]; then
         echo "Using ALL available devices"
-        $SUDO "$CEPHADM" shell ceph orch apply osd --all-available-devices
+        $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell ceph orch apply osd --all-available-devices
     else
         for item in "${DEVICES[@]}"; do
             echo "Creating osd $item on node $HOSTNAME"
-            $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+            $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
                 --keyring $CEPH_KEYRING -- ceph orch daemon add osd "$HOSTNAME:$item"
         done
     fi
 
     while [ "$ATTEMPTS" -ne 0 ]; do
-        num_osds=$($SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+        num_osds=$($SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
             --keyring $CEPH_KEYRING -- ceph -s -f json | jq '.osdmap | .num_up_osds')
         if [ "$num_osds" -ge "$MIN_OSDS" ]; then
             break;
@@ -306,12 +303,12 @@ function add_pools {
     [ "${#POOLS[@]}" -eq 0 ] && return;
 
     for pool in "${POOLS[@]}"; do
-        $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+        $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
             --keyring $CEPH_KEYRING -- ceph osd pool create "$pool" "$DEFAULT_PG_NUM" \
             "$DEFAULT_PGP_NUM" replicated --autoscale-mode on
 
         # set the application to the pool (which also means rbd init the pool)
-        $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+        $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
             --keyring $CEPH_KEYRING -- ceph osd pool application enable "$pool" rbd
     done
 }
@@ -339,7 +336,7 @@ function _create_key {
         osd_caps="allow class-read object_prefix rbd_children, $caps"
     fi
 
-    $SUDO "$CEPHADM" shell -v "$KEY_EXPORT_DIR:$KEY_EXPORT_DIR" --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell -m ${KEY_EXPORT_DIR}:${KEY_EXPORT_DIR} --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph auth get-or-create "$name" mgr "allow rw" mon "allow r" osd "$osd_caps" \
         -o "$KEY_EXPORT_DIR/ceph.$name.keyring"
 
@@ -362,11 +359,11 @@ function cephfs_config {
     # - cephfs.$FSNAME.data
     # - cephfs.$FSNAME.meta
     # and the mds daemon is deployed
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph fs volume create "$FSNAME"
 }
 
-# Get Ceph version
+# Gets Ceph version in semver format (e.g. "20.2.1", "19.2.3")
 function _get_ceph_version {
     local ceph_version_str
 
@@ -376,20 +373,28 @@ function _get_ceph_version {
     echo $ceph_version_str
 }
 
-function _install_and_configure_clustered_nfs {
-    local ceph_version
-    ceph_version=$(_get_ceph_version)
+# Gets Ceph release codename (e.g. "tentacle, "squid", ...)
+function _get_ceph_codename {
+    local ceph_version_str
 
+    ceph_version_str=$(sudo podman run --rm --entrypoint ceph $CONTAINER_IMAGE \
+        --version | awk '{ print $5 }')
+
+    echo $ceph_version_str
+}
+
+function _install_and_configure_clustered_nfs {
     echo "[CEPHADM] Deploy nfs.$FSNAME backend"
+    ceph_version=$(_get_ceph_version)
     if [[ "${ceph_version%%\.*}" -ge 18 && $ENABLE_INGRESS == "True" ]]; then
-        $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+        $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
             --keyring $CEPH_KEYRING -- ceph nfs cluster create \
             "$FSNAME" "$HOSTNAME" --port $NFS_PORT --ingress \
             --ingress-mode haproxy-protocol --virtual_ip $VIP
     else
         echo "[CEPHADM] Ingress service is not deployed \
         to preserve the ability to apply client restrictions."
-        $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+        $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
             --keyring $CEPH_KEYRING -- ceph nfs cluster create \
             "$FSNAME" "$HOSTNAME" --port $NFS_PORT
     fi
@@ -418,7 +423,7 @@ function _create_swift_endpoint {
     swift_service=$(get_or_create_service "swift" "object-store" "Swift Service")
 
     local swift_endpoint
-    swift_endpoint="$SWIFT_SERVICE_PROTOCOL://$SERVICE_HOST:${CEPH_RGW_PORT}/swift/v1"
+    swift_endpoint="$SWIFT_SERVICE_PROTOCOL://$SERVICE_HOST:${RGW_PORT}/swift/v1/AUTH_%(project_id)s"
 
     get_or_create_endpoint $swift_service \
         "$REGION_NAME" $swift_endpoint $swift_endpoint $swift_endpoint
@@ -449,17 +454,16 @@ function set_config_key {
     local section=$1
     local key=$2
     local value=$3
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
-        ceph config set ${section} ${key} ${value}
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG --keyring $CEPH_KEYRING  \
+        -- ceph config set ${section} ${key} ${value}
 }
 
 # RGW config keys: no iniset anymore, everything is pushed as mgr key/value
 function configure_rgw_ceph_section {
-
     # RGW KEYSTONE KEYS
     declare -A RGW_CONFIG_KEYS
 
-    RGW_CONFIG_KEYS=(['rgw_keystone_api_version']=3
+    RGW_CONFIG_KEYS=(
         ['rgw_keystone_url']="$KEYSTONE_SERVICE_URI"
         ['rgw_keystone_accepted_roles']="member, _member_, Member, admin"
         ['rgw_keystone_accepted_admin_roles']="ResellerAdmin"
@@ -482,6 +486,16 @@ function configure_rgw_ceph_section {
     for k in ${!RGW_CONFIG_KEYS[@]}; do
         set_config_key "global" ${k} ${RGW_CONFIG_KEYS[$k]}
     done
+
+    # Restart rgw to apply the new config
+    rgw_orch_name=$(sudo ceph orch ls | grep rgw | awk '{print $1}')
+    if [[ "${rgw_orch_name}" == "" ]]; then
+        echo "[CEPHADM] error searching for RGW daemon"
+        exit 1
+    fi
+    sudo ceph orch restart "${rgw_orch_name}"
+    # Wait for the rgw to be up and running before returning
+    sleep "10"
 }
 
 # Deploy rbd-mirror on the current site
@@ -499,7 +513,7 @@ function configure_rgw_ceph_section {
 
 function rbd_mirror {
 
-    $SUDO "$CEPHADM" shell --fsid "$FSID" --config "$CEPH_CONFIG" \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid "$FSID" --config "$CEPH_CONFIG" \
         --keyring $CEPH_KEYRING -- ceph orch apply rbd-mirror \
         "--placement=$HOSTNAME count:1"
 }
@@ -508,8 +522,8 @@ function rbd_mirror {
 function rgw {
     configure_ceph_embedded_rgw
 
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
-        --keyring $CEPH_KEYRING -- ceph orch apply rgw default default default default \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
+        --keyring $CEPH_KEYRING -- ceph orch apply rgw default default \
         "--placement=$HOSTNAME count:1" --port "$RGW_PORT"
 
     configure_rgw_ceph_section
@@ -601,9 +615,9 @@ function stop_ceph {
     cluster_deleted=0
     timeout=3
     while : ; do
-        CLUSTER_FSID=$(sudo cephadm ls | jq '.[]' | jq 'select(.name | test("^mon*")).fsid' | tr -d \")
+        CLUSTER_FSID=$(${SUDO} "${CEPHADM}" --image ${CONTAINER_IMAGE} ls | jq '.[]' | jq 'select(.name | test("^mon*")).fsid' | tr -d \")
         if [[ -n "$CLUSTER_FSID" ]]; then
-            sudo cephadm rm-cluster --zap-osds --fsid $CLUSTER_FSID --force
+            ${SUDO} "${CEPHADM}" --image ${CONTAINER_IMAGE} rm-cluster --zap-osds --fsid $CLUSTER_FSID --force
         else
             cluster_deleted=1
             echo "[CEPHADM] Cluster deleted"
@@ -694,15 +708,15 @@ function config_nova {
 
 function set_min_client_version {
     if [ ! -z "$CEPH_MIN_CLIENT_VERSION" ]; then
-        $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+        $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
             --keyring $CEPH_KEYRING -- ceph osd set-require-min-compat-client ${CEPH_MIN_CLIENT_VERSION}
     fi
 }
 
 function set_memory_config {
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph config get osd osd_memory_target
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph config set osd osd_memory_target \
         2147483648
 }
@@ -815,7 +829,7 @@ function cleanup_ceph {
 function disable_cephadm {
     local attempts=30
     while [ "$attempts" -ne 0 ]; do
-        if $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+        if $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
                 --keyring $CEPH_KEYRING -- ceph orch set backend 2>/dev/null; then
             break
         fi
@@ -824,7 +838,7 @@ function disable_cephadm {
         sleep 1
     done
 
-    $SUDO "$CEPHADM" shell --fsid $FSID --config $CEPH_CONFIG \
+    $SUDO "$CEPHADM" --image ${CONTAINER_IMAGE} shell --fsid $FSID --config $CEPH_CONFIG \
         --keyring $CEPH_KEYRING -- ceph mgr module disable cephadm
 }
 
@@ -845,6 +859,7 @@ function is_ceph_enabled_for_service {
     fi
     return $enabled
 }
+
 
 # Restore xtrace
 $XTRACE

--- a/examples/ceph-with-rgw-local.conf
+++ b/examples/ceph-with-rgw-local.conf
@@ -1,0 +1,35 @@
+[[local|localrc]]
+ADMIN_PASSWORD=secret
+DATABASE_PASSWORD=root
+RABBIT_PASSWORD=secret
+SERVICE_PASSWORD=secret
+INSTALL_TEMPEST=False
+LOGFILE=/opt/stack/devstack.log
+LOG_COLOR=True
+VERBOSE=True
+SERVICE_TIMEOUT=600
+
+# Change Ceph Version by changing tag in CONTAINER_IMAGE.
+# Supported versions are:
+#   reef: quay.io/ceph/ceph:v18
+#   squid: quay.io/ceph/ceph:v19
+#   tentacle: quay.io/ceph/ceph:v20
+# CONTAINER_IMAGE=quay.io/ceph/ceph:v20
+
+
+# Override HOST_IP to private IP address if public IP is auto-detected
+HOST_IP=
+# Setup Ceph with Rados Gateway
+RGW_PORT="8086"
+ENABLE_CEPH_CINDER=True     # ceph backend for cinder
+ENABLE_CEPH_GLANCE=True     # store images in ceph
+ENABLE_CEPH_C_BAK=True      # backup volumes to ceph
+ENABLE_CEPH_NOVA=True       # allow nova to use ceph resources
+# ENABLE_CEPH_MANILA=True     # allow manila to use CephFS as backend (Native CephFS or CephFS via NFS)
+ENABLE_CEPH_RGW=True
+CINDER_TARGET_HELPER=tgtadm
+
+ENABLED_SERVICES=",-horizon,-tempest,-dstat"
+disable_service horizon tempest
+enable_service key rabbit mysql c-bak c-api c-vol c-sch n-api n-crt n-cpu n-cond n-sch n-api-meta n-sproxy placement-api placement-client
+enable_plugin devstack-plugin-ceph https://opendev.org/openstack/devstack-plugin-ceph


### PR DESCRIPTION
- Fix: Fix `ceph orch` command with quadruple arg `ceph orch apply rgw default default default default` (2 are supported).
- Fix: Make the script correctly use overriden Ceph release version.
- Fix: Correct the swift endpoint URL to include `AUTH_<project_id>` in path (required when `rgw_swift_account_in_url` is `true` which it is).
- Fix: Restart ceph after changing configuration to make it effective.
- Docs: Add documentation for setup with RadosGW.
- Docs: Document ceph release versions that the script supports (v18 up to latest v20).
- Docs: Add well tested example config.

Change-Id: I4efa5ab5f74b52a5a1400ca76f273249f47cbc89